### PR TITLE
Bugfix: Share store URI - message was empty.

### DIFF
--- a/android/src/main/kotlin/org/ligi/survivalmanual/ui/MainActivity.kt
+++ b/android/src/main/kotlin/org/ligi/survivalmanual/ui/MainActivity.kt
@@ -198,7 +198,7 @@ class MainActivity : AppCompatActivity() {
         org.ligi.survivalmanual.R.id.menu_share -> {
             EventTracker.trackGeneric("share")
             val intent = Intent(Intent.ACTION_SEND)
-            intent.putExtra(Intent.EXTRA_TEXT, RateSnack().getUri(this))
+            intent.putExtra(Intent.EXTRA_TEXT, RateSnack().getUri(this).toString())
             intent.type = "text/plain"
             startActivity(Intent.createChooser(intent, null))
             true


### PR DESCRIPTION
+ Related commit: a9698d28173dadb1c9931ea51628694d5ba615e5

---

When I share the app store URI from the toolbar menu the message contains nothing. The URI is lost because the Intent expects a CharSequence/String.

``` java
W  java.lang.ClassCastException: android.net.Uri$StringUri 
     cannot be cast to java.lang.CharSequence
W      at android.os.BaseBundle.getCharSequence(BaseBundle.java:959)
W      at android.os.Bundle.getCharSequence(Bundle.java:694)
W      at android.content.Intent.getCharSequenceExtra(Intent.java:5363)
```